### PR TITLE
Added event for removing a reference; functionality stopped working afte...

### DIFF
--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
@@ -47,6 +47,13 @@ jQuery(function(jq) {
       return false;
       });
 
+  // remove an already existing reference
+  jq('input.destructive', jq('body')[0]).live('click', function(event) {
+      var wrap = jq(this).parent().parent();
+      target = wrap.find('input[id^=ref_browser_]');
+      target.attr("value", "");
+  });
+
   // the links for inserting referencens
   jq('[id^=atrb_] input.insertreference', jq('body')[0]).live('click', function(event) {
       var target = jq(this);

--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.pt
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.pt
@@ -193,10 +193,9 @@
                            popup_height widget/popup_height|string:550;"
                tal:attributes="src string:${startup_directory}/refbrowser_popup?fieldName=${fieldName}&amp;fieldRealName=${field/getName}&amp;at_url=${at_url};
                            rel string:#${overlay_id}" />
-        <input type="button" class="destructive" value="Clear reference" onclick=""
+        <input type="button" class="destructive" value="Clear reference"
                i18n:attributes="value label_remove_reference;"
-               tal:condition="not:multiValued"
-               tal:attributes="onclick string:javascript:refbrowser_removeReference('ref_browser_${fieldName}', ${multiValued})" />
+               tal:condition="not:multiValued" />
            </div><div id="atrb" tal:attributes="id overlay_id" class="overlay overlay-ajax"><div class="close"><span>Close</span></div>
            <div class="pb-ajax">
              <!-- <a href="" i18n:translate="referencebrowser_back" class="refbrowser_back">Back</a> -->


### PR DESCRIPTION
...r wrapping in jQuery.

This is probably not the best fix possible, but it solves the problem of no longer being able to remove a reference. The onClick attribute was removed from the template and a simple event handler was added to the javascript.
