### PR TITLE
Add a label in the popup widget for the image preview.

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -9,6 +9,8 @@ Changelog
 - Fixing reference sorting issue due to global function refactoring done
   on recent versions
   [keul]
+- Add labels for images in the popup widget.
+  [mitakas]
 
 2.5.2 (2014-09-11)
 ------------------

--- a/src/archetypes/referencebrowserwidget/browser/popup.pt
+++ b/src/archetypes/referencebrowserwidget/browser/popup.pt
@@ -192,9 +192,12 @@
         </td>
 
         <td tal:condition="image_portal_types">
-          <img tal:condition="python: item.Type in image_portal_types"
-               tal:attributes="src string:${item/getURL}/$image_method"
-               />
+          <label tal:condition="referenceable"
+                 tal:attributes="for uid;">
+            <img tal:condition="python: item.Type in image_portal_types"
+                 tal:attributes="src string:${item/getURL}/$image_method"
+                 />
+          </label>
         </td>
         <td tal:attributes="class python:'contenttype-' + normalizeString(item.portal_type)">
           <img tal:define="icon item/getIcon"

--- a/src/archetypes/referencebrowserwidget/browser/popup.pt
+++ b/src/archetypes/referencebrowserwidget/browser/popup.pt
@@ -192,7 +192,7 @@
         </td>
 
         <td tal:condition="image_portal_types">
-          <label tal:condition="referenceable"
+          <label tal:omit-tag="not: referenceable"
                  tal:attributes="for uid;">
             <img tal:condition="python: item.Type in image_portal_types"
                  tal:attributes="src string:${item/getURL}/$image_method"


### PR DESCRIPTION
The name of the image already has a label, but I often click on an image and expect it to toggle the checkbox.