### PR TITLE
Fix sorting referenced items

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,8 +4,9 @@ Changelog
 2.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fixing reference sorting issue due to global function refactoring done
+  on recent versions
+  [keul]
 
 2.5.2 (2014-09-11)
 ------------------

--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,6 +4,8 @@ Changelog
 2.5.3 (unreleased)
 ------------------
 
+- Replaced ``jq`` usage with ``$``
+  [keul]
 - Fixing reference sorting issue due to global function refactoring done
   on recent versions
   [keul]

--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
@@ -454,7 +454,17 @@ jQuery(function (jq) {
                 multivalued = $(this).data('multivalued');
             refbrowser_removeReference('ref_browser_' + fieldname, multivalued);
         });
-    });
 
+        jq('a[data-move-direction]').click(function (event) {
+            event.preventDefault();
+            var direction = jq(this).attr('data-move-direction');
+            if (direction=='up') {
+                refbrowser_moveReferenceUp(this);
+            } else {
+                refbrowser_moveReferenceDown(this);
+            }
+
+        });
+    });
 
 });

--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
@@ -1,14 +1,14 @@
-jQuery(function (jq) {
+jQuery(function ($) {
 
     // Move the overlay div to be a direct child
     // of body to avoid IE7 z-index bug.
     // TODO: load this with prepOverlay to standardize this.
-    jq('[id^=atrb_]').detach().appendTo("body");
+    $('[id^=atrb_]').detach().appendTo("body");
 
     // the overlay itself
-    jq('.addreference').overlay({
+    $('.addreference').overlay({
         onBeforeLoad: function () {
-            ov = jq('div#content').data('overlay');
+            ov = $('div#content').data('overlay');
             // close overlay, if there is one already
             // we only allow one referencebrowser per time
             if (ov) {
@@ -18,7 +18,7 @@ jQuery(function (jq) {
             var src = this.getTrigger().attr('src');
             var srcfilter = src + ' >*';
             wrap.data('srcfilter', srcfilter);
-            jq('div#content').data('overlay', this);
+            $('div#content').data('overlay', this);
             resetHistory();
             wrap.load(srcfilter, function () {
                 var fieldname = wrap.find('input[name=fieldName]').attr('value');
@@ -32,8 +32,8 @@ jQuery(function (jq) {
     });
 
     // the breadcrumb-links and the links of the 'tree'-navigati        on
-    jq(document).on('click', '[id^=atrb_] a.browsesite', function (event) {
-        var target = jq(this);
+    $(document).on('click', '[id^=atrb_] a.browsesite', function (event) {
+        var target = $(this);
         var src = target.attr('href');
         var wrap = target.parents('.overlaycontent');
         var srcfilter = src + ' >*';
@@ -51,8 +51,8 @@ jQuery(function (jq) {
     });
 
     // the links for inserting referencens
-    jq(document).on('click', '[id^=atrb_] input.insertreference', function (event) {
-        var target = jq(this);
+    $(document).on('click', '[id^=atrb_] input.insertreference', function (event) {
+        var target = $(this);
         var wrap = target.parents('.overlaycontent');
         var fieldname = wrap.find('input[name=fieldName]').attr('value');
         var multi = wrap.find('input[name=multiValued]').attr('value');
@@ -74,7 +74,7 @@ jQuery(function (jq) {
             messageId = '#messageRemoved';
         }
         if (close_window === '1' && multi !== '1') {
-            overlay = jq('div#content').data('overlay');
+            overlay = $('div#content').data('overlay');
             overlay.close();
         } else {
             showMessage(messageId, title);
@@ -83,20 +83,20 @@ jQuery(function (jq) {
 
 
     // the history menu
-    jq(document).on('change', '[id^=atrb_] form#history select[name=path]', function (event) {
-        var target = jq(this);
+    $(document).on('change', '[id^=atrb_] form#history select[name=path]', function (event) {
+        var target = $(this);
         var wrap = target.parents('.overlaycontent');
         var src_selector = '[id^=atrb_] form#history ' +
             'select[name=path] :selected';
-        var src = jq(src_selector).attr('value');
+        var src = $(src_selector).attr('value');
         var srcfilter = src + ' >*';
         refreshOverlay(wrap, srcfilter, '');
         return false;
     });
 
     // the pagination links
-    jq(document).on('click', '[id^=atrb_] .listingBar a', function (event) {
-        var target = jq(this);
+    $(document).on('click', '[id^=atrb_] .listingBar a', function (event) {
+        var target = $(this);
         var src = target.attr('href');
         var wrap = target.parents('.overlaycontent');
         var srcfilter = src + ' >*';
@@ -108,7 +108,7 @@ jQuery(function (jq) {
 
     function do_atref_search(event) {
         event.preventDefault();
-        var target = jq(event.target);
+        var target = $(event.target);
         var src = target.parents('form').attr('action');
         var wrap = target.parents('.overlaycontent');
         var fieldname = wrap.find('input[name=fieldName]').attr('value');
@@ -135,15 +135,15 @@ jQuery(function (jq) {
 
     // the search form
     // // This does not catch form submission via enter in FF but does in IE
-    jq(document).on('submit', '[id^=atrb_] form#search', do_atref_search);
+    $(document).on('submit', '[id^=atrb_] form#search', do_atref_search);
     //     // This catches form submission in FF
-    jq(document).on('click', '[id^=atrb_] form#search input[name=submit]', do_atref_search);
+    $(document).on('click', '[id^=atrb_] form#search input[name=submit]', do_atref_search);
 
     function disablecurrentrelations(widget_id) {
-        jq('ul#' + widget_id + ' :input').each(
+        $('ul#' + widget_id + ' :input').each(
             function (intIndex) {
-                uid = jq(this).attr('value');
-                cb = jq('input[rel=' + uid + ']');
+                uid = $(this).attr('value');
+                cb = $('input[rel=' + uid + ']');
                 cb.attr('disabled', 'disabled');
                 cb.attr('checked', 'checked');
             });
@@ -166,11 +166,11 @@ jQuery(function (jq) {
         // differentiate between the single and mulitselect widget
         // since the single widget has an extra label field.
         if (multi === 0) {
-            jq('#' + widget_id).attr('value', uid);
-            jq('#' + widget_id + '_label').attr('value', label);
+            $('#' + widget_id).attr('value', uid);
+            $('#' + widget_id + '_label').attr('value', label);
         } else {
             // check if the item isn't already in the list
-            current_values = jq('#' + widget_id + ' input');
+            current_values = $('#' + widget_id + ' input');
             for (i = 0; i < current_values.length; i++) {
                 if (current_values[i].value === uid) {
                     return false;
@@ -181,11 +181,11 @@ jQuery(function (jq) {
             list = document.getElementById(widget_id);
             // add ul-element to DOM, if it is not there
             if (list === null) {
-                container = jq('#archetypes-fieldname-' + fieldname +
+                container = $('#archetypes-fieldname-' + fieldname +
                     ' input + div');
                 if (!container.length) {
                     // fix for Plone 3.3 collections, with a weird widget-id
-                    container = jq('#archetypes-fieldname-value input + div');
+                    container = $('#archetypes-fieldname-value input + div');
                 }
                 container.after(
                     '<ul class="visualNoMarker" id="' + widget_id + '"></ul>');
@@ -203,7 +203,7 @@ jQuery(function (jq) {
             li.appendChild(label_element);
             li.id = 'ref-' + fieldname + '-' + current_values.length;
 
-            sortable = jq('input[name=' + fieldname + '-sortable]').attr('value');
+            sortable = $('input[name=' + fieldname + '-sortable]').attr('value');
             if (sortable === '1') {
                 up_element = document.createElement('a');
                 up_element.title = 'Move Up';
@@ -237,7 +237,7 @@ jQuery(function (jq) {
     // remove the item for the uid from the reference widget
     function refbrowser_delReference(fieldname, uid) {
         var selector = 'input[value="' + uid + '"][name="' + fieldname + ':list"]',
-            inputs = jq(selector);
+            inputs = $(selector);
         inputs.closest('li').remove();
     }
 
@@ -260,8 +260,8 @@ jQuery(function (jq) {
                 list[x].selected = 'selected';
             }
         } else {
-            jq('#' + widget_id).attr('value', "");
-            jq('#' + widget_id + '_label').attr('value', "");
+            $('#' + widget_id).attr('value', "");
+            $('#' + widget_id + '_label').attr('value', "");
         }
     }
 
@@ -327,7 +327,7 @@ jQuery(function (jq) {
         eid = elem.id.split('-');
         pos = parseInt(eid.pop(), 10);
         widget_id = eid.pop();
-        current_values = jq('#ref_browser_items_' + widget_id + ' input');
+        current_values = $('#ref_browser_items_' + widget_id + ' input');
         if ((pos + 1) === current_values.length) {
             return false;
         }
@@ -360,11 +360,11 @@ jQuery(function (jq) {
     }
 
     function showMessage(messageId, text) {
-        var template = jq(messageId).parent(),
+        var template = $(messageId).parent(),
             message_div = template.clone(),
             message = message_div.children(),
-            old_message = jq('#message'),
-            message_wrapper = jq('#messageWrapper');
+            old_message = $('#message'),
+            message_wrapper = $('#messageWrapper');
 
         // insert a new, cloned message
         message_wrapper.prepend(message_div);
@@ -392,28 +392,28 @@ jQuery(function (jq) {
     }
 
     function pushToHistory(url) {
-        var history = jq(document).data('atrb_history');
+        var history = $(document).data('atrb_history');
         history.push(url);
-        jq(document).data('atrb_history', history);
+        $(document).data('atrb_history', history);
     }
 
     function resetHistory() {
-        jq(document).data('atrb_history', []);
+        $(document).data('atrb_history', []);
     }
 
     function popFromHistory() {
-        var history = jq(document).data('atrb_history');
+        var history = $(document).data('atrb_history');
         value = history.pop();
-        jq(document).data('atrb_history', history);
+        $(document).data('atrb_history', history);
         return value;
     }
 
     function refreshOverlay(wrap, srcfilter, newoption) {
-        var oldhistory = jq('[id^=atrb_] form#history select');
+        var oldhistory = $('[id^=atrb_] form#history select');
         wrap.load(srcfilter, function () {
-            jq('[id^=atrb_] form#history select').append(newoption +
+            $('[id^=atrb_] form#history select').append(newoption +
                 oldhistory.html());
-            ov = jq('div#content').data('overlay');
+            ov = $('div#content').data('overlay');
             widget_id = ov.getTrigger().attr('rel').substring(6);
             disablecurrentrelations(widget_id);
             var fieldname = wrap.find('input[name=fieldName]').attr('value');
@@ -423,19 +423,19 @@ jQuery(function (jq) {
 
     // check all references in the overlay that are present in the widget
     function check_referenced_items(fieldname) {
-        var refs_in_overlay = jq('input.insertreference'),
+        var refs_in_overlay = $('input.insertreference'),
             uid_selector = "input[name='" + fieldname + ":list']",
-            current = jq(uid_selector), // the widget in the form
+            current = $(uid_selector), // the widget in the form
             current_uids = current.map(function () {
                 if (this.checked === true) {
-                    return jq(this).attr('value');
+                    return $(this).attr('value');
                 }
                 return null;
             });
 
         refs_in_overlay.each(function () {
-            var overlay_ref = jq(this),
-                uid = jq(overlay_ref).attr('rel'),
+            var overlay_ref = $(this),
+                uid = $(overlay_ref).attr('rel'),
                 i;
 
             for (i = 0; i < current_uids.length; i++) {
@@ -447,17 +447,17 @@ jQuery(function (jq) {
         });
     }
 
-    jq(document).ready(function () {
-        jq('input.removereference').click(function (event) {
+    $(document).ready(function () {
+        $('input.removereference').click(function (event) {
             event.preventDefault();
             var fieldname = $(this).data('fieldname'),
                 multivalued = $(this).data('multivalued');
             refbrowser_removeReference('ref_browser_' + fieldname, multivalued);
         });
 
-        jq('a[data-move-direction]').click(function (event) {
+        $('a[data-move-direction]').click(function (event) {
             event.preventDefault();
-            var direction = jq(this).attr('data-move-direction');
+            var direction = $(this).attr('data-move-direction');
             if (direction=='up') {
                 refbrowser_moveReferenceUp(this);
             } else {

--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.pt
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.pt
@@ -173,10 +173,8 @@
               </label>
 
               <tal:sorting condition="widget/allow_sorting">
-                <a href="" title="Move up"
-                    onclick="javascript:refbrowser_moveReferenceUp(this); return false">&#x25b2;</a>
-                <a href="" title="Move down"
-                    onclick="javascript:refbrowser_moveReferenceDown(this); return false">&#x25bc;</a>
+                <a href="" title="Move up" data-move-direction="up">&#x25b2;</a>
+                <a href="" title="Move down" data-move-direction="down">&#x25bc;</a>
               </tal:sorting>
 
             </li>

--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.pt
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.pt
@@ -173,8 +173,10 @@
               </label>
 
               <tal:sorting condition="widget/allow_sorting">
-                <a href="" title="Move up" data-move-direction="up">&#x25b2;</a>
-                <a href="" title="Move down" data-move-direction="down">&#x25bc;</a>
+                <a href="" title="Move up" data-move-direction="up"
+                   i18n:translate="title">&#x25b2;</a>
+                <a href="" title="Move down" data-move-direction="down"
+                   i18n:translate="title">&#x25bc;</a>
               </tal:sorting>
 
             </li>


### PR DESCRIPTION
Sorting referenced items UI was totally broken due to changes done to widget's JavaScript.

As global function ``refbrowser_moveReferenceUp`` is not more global I replicated the same patterns done for ``refbrowser_removeReference``.