### PR TITLE
This is a proposal for new feature widget.use_wildcard_search

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -13,10 +13,13 @@ Changelog
 
 - #16 fix browsing for widgets in case field has set ``allowed_types``
 
-  (Warning: changed return value of view/getResult from 
+  (Warning: changed return value of view/getResult from
   `[`brain1, brain2,..]``  to ``[dict(item=brain1,browsable=True,
-  referenceable=False),...]`` in case you customized popup.pt) 
+  referenceable=False),...]`` in case you customized popup.pt)
   [fRiSi]
+
+- #23 added parameter 'use_wildcard_search' to widget, True by default
+  [gbastien]
 
 
 2.5.2 (2014-09-11)
@@ -25,7 +28,7 @@ Changelog
 - Fix the "Clear Reference" button, which was not working due to the
   refbrowser_removeReference function hidden in a anonymous function.
   [thet]
-  
+
 - fixed allowed_types
   [agitator]
 
@@ -375,4 +378,3 @@ Changelog
 
 - Merged javascript files to one, which is included only with the widget
   [tom_gross]
-

--- a/src/archetypes/referencebrowserwidget/browser/popup.pt
+++ b/src/archetypes/referencebrowserwidget/browser/popup.pt
@@ -17,6 +17,7 @@
                   search_index view/search_index;
                   search_text view/search_text;
                   wildcardable_indexes view/wildcardable_indexes;
+                  wildcardable_indexes_as_json view/wildcardable_indexes_as_json;
                   available_indexes widget/available_indexes;
                   allow_browse widget/allow_browse;
                   image_portal_types widget/image_portal_types;
@@ -105,7 +106,7 @@
               i18n:attributes="title"
               data-wildcardableIndexes="#"
               tal:attributes='title python: widget.use_wildcard_search and "wild_card_search_enabled_help" or "wild_card_search_disabled_help";
-                              data-wildcardableIndexes wildcardable_indexes'>?</span>
+                              data-wildcardableIndexes wildcardable_indexes_as_json'>?</span>
       </div>
      </tal:formactions>
 

--- a/src/archetypes/referencebrowserwidget/browser/popup.pt
+++ b/src/archetypes/referencebrowserwidget/browser/popup.pt
@@ -105,8 +105,8 @@
               tal:condition="python: search_index in wildcardable_indexes"
               i18n:attributes="title"
               data-wildcardableIndexes="#"
-              tal:attributes='title python: widget.use_wildcard_search and "wild_card_search_enabled_help" or "wild_card_search_disabled_help";
-                              data-wildcardableIndexes wildcardable_indexes_as_json'>?</span>
+              tal:attributes="title view/wildcard_help_message;
+                              data-wildcardableIndexes wildcardable_indexes_as_json">?</span>
       </div>
      </tal:formactions>
 

--- a/src/archetypes/referencebrowserwidget/browser/popup.pt
+++ b/src/archetypes/referencebrowserwidget/browser/popup.pt
@@ -16,6 +16,7 @@
                   title python:widget.Label(at_obj);
                   search_index view/search_index;
                   search_text view/search_text;
+                  wildcardable_indexes view/wildcardable_indexes;
                   available_indexes widget/available_indexes;
                   allow_browse widget/allow_browse;
                   image_portal_types widget/image_portal_types;
@@ -97,6 +98,14 @@
                i18n:domain="plone"
                i18n:attributes="value label_search;"
                />
+  &nbsp;<span style="font-weight: bold; color: grey; border-bottom: 1px dotted; cursor: help;"
+              title="#"
+              id="searchWildcardHelp"
+              tal:condition="python: search_index in wildcardable_indexes"
+              i18n:attributes="title"
+              data-wildcardableIndexes="#"
+              tal:attributes='title python: widget.use_wildcard_search and "wild_card_search_enabled_help" or "wild_card_search_disabled_help";
+                              data-wildcardableIndexes wildcardable_indexes'>?</span>
       </div>
      </tal:formactions>
 

--- a/src/archetypes/referencebrowserwidget/browser/view.py
+++ b/src/archetypes/referencebrowserwidget/browser/view.py
@@ -46,6 +46,7 @@ default_popup_template = named_template_adapter(
     ViewPageTemplateFile('popup.pt'))
 
 PMF = MessageFactory('plone')
+RBWMF = MessageFactory('archetypes.referencebrowserwidget')
 
 
 class ReferenceBrowserHelperView(BrowserView):
@@ -274,6 +275,20 @@ class ReferenceBrowserPopup(BrowserView):
     @property
     def wildcardable_indexes_as_json(self):
         return json.dumps(self.wildcardable_indexes)
+
+    @property
+    def wildcard_help_message(self):
+        if self.widget.use_wildcard_search:
+            return RBWMF("wild_card_search_enabled_help",
+                         default="Full-text search is enabled: searching for 'budget' will also "
+                         "return elements containing 'budgetary'. If you want to search exact "
+                         "macth, add quotation marks around the word: \"budget\".")
+        else:
+            return RBWMF("wild_card_search_disabled_help",
+                         default="Full-text search is disabled: searching for 'budget' will only "
+                         "return elements containing exact term 'budget'. You can enable full-text search "
+                         "by appending a '*' at the end of a word. For example, searching for 'budget*' "
+                         "will also return elements containing 'budgetary'.")
 
     def getResult(self):
         assert self._updated

--- a/src/archetypes/referencebrowserwidget/browser/view.py
+++ b/src/archetypes/referencebrowserwidget/browser/view.py
@@ -46,7 +46,7 @@ default_popup_template = named_template_adapter(
     ViewPageTemplateFile('popup.pt'))
 
 PMF = MessageFactory('plone')
-RBWMF = MessageFactory('archetypes.referencebrowserwidget')
+_ = MessageFactory('archetypes.referencebrowserwidget')
 
 
 class ReferenceBrowserHelperView(BrowserView):
@@ -279,16 +279,16 @@ class ReferenceBrowserPopup(BrowserView):
     @property
     def wildcard_help_message(self):
         if self.widget.use_wildcard_search:
-            return RBWMF("wild_card_search_enabled_help",
-                         default="Full-text search is enabled: searching for 'budget' will also "
-                         "return elements containing 'budgetary'. If you want to search exact "
-                         "macth, add quotation marks around the word: \"budget\".")
+            return _("wild_card_search_enabled_help",
+                     default="Full-text search is enabled: searching for 'budget' will also "
+                     "return elements containing 'budgetary'. If you want to search exact "
+                     "match, add quotation marks around the word: \"budget\".")
         else:
-            return RBWMF("wild_card_search_disabled_help",
-                         default="Full-text search is disabled: searching for 'budget' will only "
-                         "return elements containing exact term 'budget'. You can enable full-text search "
-                         "by appending a '*' at the end of a word. For example, searching for 'budget*' "
-                         "will also return elements containing 'budgetary'.")
+            return _("wild_card_search_disabled_help",
+                     default="Full-text search is disabled: searching for 'budget' will only "
+                     "return elements containing exact term 'budget'. You can enable full-text search "
+                     "by appending a '*' at the end of a word. For example, searching for 'budget*' "
+                     "will also return elements containing 'budgetary'.")
 
     def getResult(self):
         assert self._updated

--- a/src/archetypes/referencebrowserwidget/browser/view.py
+++ b/src/archetypes/referencebrowserwidget/browser/view.py
@@ -1,4 +1,5 @@
 from types import ListType, TupleType
+import json
 import urllib
 import re
 
@@ -39,7 +40,7 @@ from archetypes.referencebrowserwidget import utils
 from archetypes.referencebrowserwidget.config import WILDCARDABLE_INDEXES
 from archetypes.referencebrowserwidget.interfaces import IFieldRelation
 from archetypes.referencebrowserwidget.interfaces import \
-        IReferenceBrowserHelperView
+    IReferenceBrowserHelperView
 
 default_popup_template = named_template_adapter(
     ViewPageTemplateFile('popup.pt'))
@@ -269,6 +270,10 @@ class ReferenceBrowserPopup(BrowserView):
         assert self._updated
         indexes = self.search_catalog.Indexes.values()
         return [index.getId() for index in indexes if index.getTagName() in WILDCARDABLE_INDEXES]
+
+    @property
+    def wildcardable_indexes_as_json(self):
+        return json.dumps(self.wildcardable_indexes)
 
     def getResult(self):
         assert self._updated

--- a/src/archetypes/referencebrowserwidget/browser/view.py
+++ b/src/archetypes/referencebrowserwidget/browser/view.py
@@ -264,6 +264,12 @@ class ReferenceBrowserPopup(BrowserView):
         avail = self.widget.available_indexes
         return [index for index in indexes if not avail or index in avail]
 
+    @property
+    def wildcardable_indexes(self):
+        assert self._updated
+        indexes = self.search_catalog.Indexes.values()
+        return [index.getId() for index in indexes if index.getTagName() in WILDCARDABLE_INDEXES]
+
     def getResult(self):
         assert self._updated
         result = []
@@ -271,7 +277,7 @@ class ReferenceBrowserPopup(BrowserView):
         # turn search string into a wildcard search if relevant, so if
         # wild_card_search is True and if current index is a ZCTextIndex
         index = self.search_catalog.Indexes[self.search_index]
-        if self.search_text and self.widget.use_wildcard_search and index.getTagName() in WILDCARDABLE_INDEXES:
+        if self.search_text and self.widget.use_wildcard_search and index.getId() in self.wildcardable_indexes:
             # only append a '*' if not already ending with a '*' and not surrounded
             # by " ", this is the case if user want to search exact match
             if not self.search_text.endswith('*') and \

--- a/src/archetypes/referencebrowserwidget/browser/view.py
+++ b/src/archetypes/referencebrowserwidget/browser/view.py
@@ -36,6 +36,7 @@ except ImportError:
 from Products.CMFPlone.PloneBatch import Batch
 
 from archetypes.referencebrowserwidget import utils
+from archetypes.referencebrowserwidget.config import WILDCARDABLE_INDEXES
 from archetypes.referencebrowserwidget.interfaces import IFieldRelation
 from archetypes.referencebrowserwidget.interfaces import \
         IReferenceBrowserHelperView
@@ -266,6 +267,17 @@ class ReferenceBrowserPopup(BrowserView):
     def getResult(self):
         assert self._updated
         result = []
+
+        # turn search string into a wildcard search if relevant, so if
+        # wild_card_search is True and if current index is a ZCTextIndex
+        index = self.search_catalog.Indexes[self.search_index]
+        if self.search_text and self.widget.use_wildcard_search and index.getTagName() in WILDCARDABLE_INDEXES:
+            # only append a '*' if not already ending with a '*' and not surrounded
+            # by " ", this is the case if user want to search exact match
+            if not self.search_text.endswith('*') and \
+               not (self.search_text.startswith('"') and self.search_text.endswith('"')):
+                self.request[self.search_index] = "{0}*".format(self.search_text)
+
         qc = getMultiAdapter((self.context, self.request),
                              name='refbrowser_querycatalog')
         if self.widget.show_results_without_query or self.search_text:

--- a/src/archetypes/referencebrowserwidget/config.py
+++ b/src/archetypes/referencebrowserwidget/config.py
@@ -1,3 +1,5 @@
 PROJECTNAME = "referencebrowserwidget"
 
 WITH_SAMPLE_TYPES = False
+
+WILDCARDABLE_INDEXES = ('ZCTextIndex', )

--- a/src/archetypes/referencebrowserwidget/demo.py
+++ b/src/archetypes/referencebrowserwidget/demo.py
@@ -51,7 +51,8 @@ schema = BaseSchema.copy() + Schema((
         widget=ReferenceBrowserWidget(
             show_indexes=1,
             history_length=5,
-            description='And here is another field.  Startup directory is /Members.',
+            use_wildcard_search=False,
+            description='And here is another field.  Startup directory is /Members.  Wildcard search is disabled.',
             startup_directory='/Members')),
 
     ReferenceField('multiRef4',

--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
@@ -448,7 +448,7 @@ jQuery(function ($) {
     }
 
     $(document).on('change', '#indexSelector', function (event) {
-        if ($.inArray(this.value, eval($('#searchWildcardHelp').data()['wildcardableindexes'])) === -1) {
+        if ($.inArray(this.value, $('#searchWildcardHelp').data()['wildcardableindexes']) === -1) {
             // make sure searchWildcardHelp is hidden
             $('#searchWildcardHelp').css("display", "none");
         }

--- a/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
+++ b/src/archetypes/referencebrowserwidget/skins/referencebrowser/referencebrowser.js
@@ -447,6 +447,17 @@ jQuery(function ($) {
         });
     }
 
+    $(document).on('change', '#indexSelector', function (event) {
+        if ($.inArray(this.value, eval($('#searchWildcardHelp').data()['wildcardableindexes'])) === -1) {
+            // make sure searchWildcardHelp is hidden
+            $('#searchWildcardHelp').css("display", "none");
+        }
+        else {
+            // make sure searchWildcardHelp is shown
+            $('#searchWildcardHelp').css("display", "");
+        }
+    });
+
     $(document).ready(function () {
         $('input.removereference').click(function (event) {
             event.preventDefault();

--- a/src/archetypes/referencebrowserwidget/widget.py
+++ b/src/archetypes/referencebrowserwidget/widget.py
@@ -40,6 +40,7 @@ class ReferenceBrowserWidget(ReferenceWidget):
         'browsable_types': (),
         'top_popup_helper': None,
         'bottom_popup_helper': None,
+        'use_wildcard_search': 1,
         })
 
     # for documentation of properties see: README.txt


### PR DESCRIPTION
Hi @keul , @frisi 

I finally had time to implement this.

widget.use_wildcard_search parameter is True by default.  A help message is displayed beside the "search" button if current index support wildcard search.  If selecting an index that does not support wildcard search, the help message is hidden, this can be the case if you use available_indexes/show_indexes with mixed wildcard able indexes and not.

I added a help message but not il plone.app.locales yet, if this PR is merged, I will finish work with p.a.locales.

I updated the demo to disable wildcard search in one case, easy to test.

Could you please review this?

Thank you!

Gauthier