### PR TITLE
typesUseViewActionInListings moved to registry

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,8 +1,14 @@
 Changelog
 =========
 
+
+
 2.5.4 (unreleased)
 ------------------
+
+- typesUseViewActionInListings moved to registry as
+  types_use_view_action_in_listings.
+  [pbauer]
 
 - saner check for isNotSelf(), which was throwing KeyError
   [alecpm, tkimnguyen]

--- a/src/archetypes/referencebrowserwidget/browser/view.py
+++ b/src/archetypes/referencebrowserwidget/browser/view.py
@@ -7,6 +7,7 @@ import zope.interface
 
 from zope.component import getAdapter
 from zope.component import getMultiAdapter, queryMultiAdapter
+from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
 from zope.formlib import namedtemplate
 
@@ -26,6 +27,7 @@ except ImportError:
 from Products.ZCTextIndex.ParseTree import ParseError
 
 from plone.app.form._named import named_template_adapter
+from plone.registry.interfaces import IRegistry
 
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.CMFCore.utils import getToolByName
@@ -417,10 +419,9 @@ class ReferenceBrowserPopup(BrowserView):
         return getattr(item, 'Title', '') or getattr(item, 'getId', '')
 
     def preview_url(self, item):
-        portal_properties = getMultiAdapter((self.context, self.request),
-                                            name=u'plone_tools').properties()
-        site_properties = portal_properties.site_properties
-        types_use_view = site_properties.typesUseViewActionInListings
+        registry = getUtility(IRegistry)
+        types_use_view = registry.get(
+            'plone.types_use_view_action_in_listings')
         if item.portal_type in types_use_view:
             return item.getURL() + '/view'
         return item.getURL()

--- a/src/archetypes/referencebrowserwidget/tests/test_product.py
+++ b/src/archetypes/referencebrowserwidget/tests/test_product.py
@@ -315,10 +315,9 @@ class PopupTestCase(PopupBaseTestCase):
         catalog = getToolByName(self.portal, 'portal_catalog')
         brain = catalog(id='ref')[0]
         assert popup.preview_url(brain) == brain.getURL()
-
+        registry = self.portal.portal_registry
         # now testing what URL is get for content's where "/view" if forced
-        site_properties = self.portal.portal_properties.site_properties
-        site_properties.typesUseViewActionInListings = ('RefBrowserDemo',)
+        registry['plone.types_use_view_action_in_listings'] = ['RefBrowserDemo']
         assert popup.preview_url(brain) == brain.getURL() + '/view'
 
     def test_at_url(self):


### PR DESCRIPTION
This breaks compatability with Plone 5, so https://github.com/plone/buildout.coredev/blob/4.3/sources.cfg would need to use a new branch.