### PR TITLE
Do not fail if a level of the path we are adding the object using the ReferenceBrowser widget is not accessible by the current user.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Do not fail if a level of the path we are adding the object using
+  the ReferenceBrowser widget is not accessible by the current user.
+  [gbastien]
 
 
 2.5.5 (2015-10-27)

--- a/src/archetypes/referencebrowserwidget/browser/view.py
+++ b/src/archetypes/referencebrowserwidget/browser/view.py
@@ -226,8 +226,8 @@ class ReferenceBrowserPopup(BrowserView):
             self.has_brain = True
             self.brainuid = at_brain.UID
         else:
-            self.at_obj = context.restrictedTraverse(
-                    urllib.unquote(self.at_url))
+            self.at_obj = context.unrestrictedTraverse(
+                urllib.unquote(self.at_url))
         self.field = self.at_obj.Schema()[self.fieldRealName]
         self.widget = self.field.widget
         self.multiValued = int(self.field.multiValued)


### PR DESCRIPTION
Hi @mauritsvanrees @pbauer 

this pull request fixes following problem :
- when creating a new AT content in a subfolder and there is a parent folder that is not accessible by current user, it raises Unauthorized because it does a restrictedTraverse to get current object.

This changes to use unrestrictedTraverse to be sure that we get the current object.  I added a test too that shows this.

Could you please review and merge if it is ok?

Thank you!

Gauthier